### PR TITLE
add working unit tests with hiera data sources

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -27,3 +27,5 @@ fixtures:
     vcsrepo:
       ref: '1.5.0'
       repo: 'https://github.com/puppetlabs/puppetlabs-vcsrepo'
+  symlinks:
+    "mystuff": "#{source_dir}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.5-alpine
+
+WORKDIR /opt/puppet
+
+ENV PUPPET_VERSION "~> 5"
+ENV PARALLEL_TEST_PROCESSORS=4
+
+RUN apk add --no-cache git bash alpine-sdk
+
+# Cache gems
+COPY Gemfile .
+RUN bundle install --without system_tests development release --path=${BUNDLE_PATH:-vendor/bundle}
+
+COPY . .
+
+RUN bundle install
+RUN bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem 'rspec-puppet'
   gem 'rspec-puppet-facts', :require => false
   gem 'hiera'
+  gem 'rspec-puppet-utils'
 end
 
 group :development, :test do

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	docker build -t puppet-hiera-test .

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-require 'rake'
-require 'rspec/core/rake_task'
 require 'puppetlabs_spec_helper/rake_tasks'
 
 desc "Run all RSpec code examples"

--- a/data/kernel/Linux.yaml
+++ b/data/kernel/Linux.yaml
@@ -1,1 +1,1 @@
-mystuff::rd::version: latest
+mystuff::rd::version: '4.1.2-29'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,12 +1,12 @@
+version: 5
+
 defaults:
   data_hash: yaml_data
   datadir: data
 
 hierarchy:
   - name: "Kernel"
-    path: "kernel/%{kernel}.yaml"
+    path: "kernel/%{facts.kernel}.yaml"
 
   - name: "Common"
     path: "common.yaml"
-
-version: 5

--- a/manifests/rd.pp
+++ b/manifests/rd.pp
@@ -1,12 +1,7 @@
 class mystuff::rd(
   String $version,
 ) {
-  class { 'java':
-    distribution => 'jre',
-  }
-
-  class { '::rundeck':
-    package_ensure => $version,
-    require        => Class['java'],
+  package {'somepackage':
+    ensure => $version
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,35 @@
+{
+  "name": "dandunckelman-mystuff",
+  "version": "1.0.0-rc0",
+  "author": "dandunckelman",
+  "summary": "Example puppet 5 data in-module testing setup",
+  "license": "MIT",
+  "source": "https://github.com/dandunckelman/puppet-hiera-test",
+  "project_page": "https://github.com/dandunckelman/puppet-hiera-test",
+  "issues_url": "https://github.com/dandunckelman/puppet-hiera-test/issues",
+  "dependencies": [
+	{
+	  "name": "puppetlabs/java",
+	  "version_requirement": "1.6.0"
+	},
+	{
+      "name": "puppet/rundeck",
+	  "version_requirement": "> 5.0.0"
+	}
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "16.04"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.10.0 < 6.0.0"
+    }
+  ]
+}

--- a/spec/classes/rd_spec.rb
+++ b/spec/classes/rd_spec.rb
@@ -1,31 +1,12 @@
 require "spec_helper"
 
-describe "mystuff::rd" do
-  hiera = Hiera.new( config: 'hiera.yaml' )
-
-  test_on = {
-    :supported_os => [
-      {
-        "operatingsystem"        => "Ubuntu",
-        "operatingsystemrelease" => ['16.04'],
-      }
-    ]
-  }
-
-  on_supported_os(test_on).each do |os, facts|
+describe "mystuff::rd", type: :class do
+  on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
 
-      # I look at this as setting the "expected" value to ensure my tests pass
-      version = hiera.lookup("mystuff::rd::version", nil, facts)
-
       it { is_expected.to compile.with_all_deps }
-      it { should contain_class("java").with_distribution("jre") }
-
-      it { should contain_class("rundeck")
-        .with_package_ensure(version)
-        .that_requires("Class[java]")
-      }
+      it { should contain_package("somepackage").with_ensure("4.1.2-29") }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,14 @@
 require "puppetlabs_spec_helper/module_spec_helper"
-require "hiera"
 require "rspec-puppet-facts"
 
 include RspecPuppetFacts
 
 RSpec.configure do |c|
-  c.hiera_config = "hiera.yaml"
+  default_facts = {
+    puppetversion: Puppet.version,
+    facterversion: Facter.version
+  }
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
+  c.default_facts = default_facts
 end


### PR DESCRIPTION
if you have docker installed, you can now run `make test` to see that this now works, otherwise execute tests as you normally do.

I changed the manifest and spec to test a simple native resource to demonstrate how data is loaded.

When I tested the existing manifest/spec, there was a problem with the fixtures, which causes problems with the `rd` class parameters because required dependencies weren't loading correctly.

As you can see, I'm running a spec that tests for `somepackage`, `with_ensure('4.1.2-29')`, which is the value I provided to `mystuff::rd::version` in `/data/kernel/Linux.yaml`.